### PR TITLE
When batch resolving, ensure output is returned in the order of the input sequence

### DIFF
--- a/src/main/com/fulcrologic/rad/database_adapters/sql/query.clj
+++ b/src/main/com/fulcrologic/rad/database_adapters/sql/query.clj
@@ -160,4 +160,4 @@
                                     joins-to-run)]
         (if one?
           (first (vals results-by-id))
-          (vec (vals results-by-id)))))))
+          (mapv results-by-id ids))))))


### PR DESCRIPTION
If using a batch resolver, the output must be in the same order of the
input sequence, otherwise the result set can be mapped to the wrong
input ids.