### PR TITLE
Support MS SQLAdapter NEXTVAL syntax 

### DIFF
--- a/src/main/com/fulcrologic/rad/database_adapters/sql/plugin.clj
+++ b/src/main/com/fulcrologic/rad/database_adapters/sql/plugin.clj
@@ -34,6 +34,9 @@
                                               :h2 (do
                                                     (log/info k "using H2 Adapter for schema" schema)
                                                     (vendor/->H2Adapter))
+                                              :mssql (do
+                                                       (log/info k "using MS SQL Adapter for schema" schema)
+                                                       (vendor/->MSSQLAdapter))
                                               default-adapter)]
                                 (assoc acc schema adapter)))
                             {}

--- a/src/main/com/fulcrologic/rad/database_adapters/sql/vendor.clj
+++ b/src/main/com/fulcrologic/rad/database_adapters/sql/vendor.clj
@@ -6,20 +6,31 @@
 (defprotocol VendorAdapter
   (relax-constraints! [this datasource] "Try to defer constraint checking until the end of txn.")
   (add-referential-column-statement [this origin-table origin-column target-type target-table target-column]
-    "Alter table and add a FK column."))
+    "Alter table and add a FK column.")
+  (next-value-for-sequence [this s] "Return next value for a sequence s"))
 
 (s/def ::adapter (s/with-gen #(satisfies? VendorAdapter %) #(s/gen #{(reify VendorAdapter)})))
 
 (deftype H2Adapter []
   VendorAdapter
   (relax-constraints! [_ ds] (jdbc/execute! ds ["SET REFERENTIAL_INTEGRITY FALSE"]))
-  (add-referential-column-statement [this origin-table origin-column target-type target-table target-column]
+  (add-referential-column-statement [_ origin-table origin-column target-type target-table target-column]
     (format "ALTER TABLE %s ADD COLUMN IF NOT EXISTS %s %s REFERENCES %s(%s);\n"
-      origin-table origin-column target-type target-table target-column)))
+            origin-table origin-column target-type target-table target-column))
+  (next-value-for-sequence [_ s]
+    (format "SELECT NEXTVAL('%s') AS id" s)))
 
 (deftype PostgreSQLAdapter []
   VendorAdapter
   (relax-constraints! [_ ds] (jdbc/execute! ds ["SET CONSTRAINTS ALL DEFERRED"]))
-  (add-referential-column-statement [this origin-table origin-column target-type target-table target-column]
+  (add-referential-column-statement [_ origin-table origin-column target-type target-table target-column]
     (format "ALTER TABLE %s ADD COLUMN IF NOT EXISTS %s %s REFERENCES %s(%s) DEFERRABLE INITIALLY DEFERRED;\n"
-      origin-table origin-column target-type target-table target-column)))
+            origin-table origin-column target-type target-table target-column))
+  (next-value-for-sequence [_ s]
+    (format "SELECT NEXTVAL('%s') AS id" s)))
+
+(deftype MSSQLAdapter []
+  VendorAdapter
+  (relax-constraints! [_ _] nil)        ;; It seems mssql cannot relax rules in a transaction
+  (next-value-for-sequence [_ s]
+    (format "SELECT NEXT VALUE FOR [%s] AS id" s)))


### PR DESCRIPTION
As stated in #13 MS SQL uses ANSI syntax to obtain next sequence value.

This patch:
- extends VendorAdapter protocol with new method
- uses current solution as a base for H2 / Postgres implementation
- adds new MSSQL Adapter

Some notable remarks:
- `relax-constraints!` is empty for MSSQL Adapter as it seems MS SQL does not have this ability. It can only disable individual table constrains using ALTER TABLE :(
- I do not use migrations so I left `add-referential-column-statemen` empty for the moment

I run `clojure -M:dev:test:clj-tests` with success. However I am afraid that the only test for INSERT I have seen call `scalar-insert`, which does not include call to `generate-tempids`. I guess that use of sequences is not covered by test.