### PR TITLE
Support cardinality :many in MS SQL: replace array_agg with Clojure fn

### DIFF
--- a/src/main/com/fulcrologic/rad/database_adapters/sql/query.clj
+++ b/src/main/com/fulcrologic/rad/database_adapters/sql/query.clj
@@ -59,7 +59,7 @@
                    table               (table-name key->attribute target-attr) ; address
                    target-id-column    (column-name target-attr) ; id
                    id-list             (str/join "," (map q ids))]
-        [(format "SELECT %1$s.%2$s AS c0, %3$s.%4$s AS c1 FROM %1$s LEFT JOIN %3$s ON %1$s.%2$s = %3$s.%5$s WHERE %1$s.%2$s IN (%6$s)"
+        [(format "SELECT %1$s.%2$s AS c0, %3$s.%4$s AS c1 FROM %1$s JOIN %3$s ON %1$s.%2$s = %3$s.%5$s WHERE %1$s.%2$s IN (%6$s)"
            rev-target-table rev-target-column table target-id-column column id-list)
          [reverse-target-attr attr]]
         (throw (ex-info "Cannot create to-many reference column." {:k qualified-key}))))))

--- a/src/test/com/fulcrologic/rad/database_adapters/sql/query_test.clj
+++ b/src/test/com/fulcrologic/rad/database_adapters/sql/query_test.clj
@@ -34,7 +34,7 @@
                          [1 2 3])]
     (assertions
       "Generates the correct SQL"
-      actual => "SELECT accounts.id AS c0, array_agg(addresses.id) AS c1 FROM accounts LEFT JOIN addresses ON accounts.id = addresses.accounts_addresses_accounts_id WHERE accounts.id IN (1,2,3) GROUP BY accounts.id"
+      actual => "SELECT accounts.id AS c0, addresses.id AS c1 FROM accounts JOIN addresses ON accounts.id = addresses.accounts_addresses_accounts_id WHERE accounts.id IN (1,2,3)"
       "Returns the attributes in the order they appear in the query"
       attrs => [attrs/account-id attrs/account-addresses])))
 


### PR DESCRIPTION
`to-many-join-column-query` uses `GROUP BY` and `array_agg` aggregate function. Unfortunately not all SQL databases implement it, SQL Server is one of them (#15).

I propose to move this functionality out of SQL to Clojure function. Return all relations and group them in Clojure code. This makes it less dependent on specific SQL implementations. One drawback could be performance (it transfers more data) but I estimate the impact will be minimal. I guess performance is not main fulcro-rad-sql concern and its performance can be tuned elsewhere (roundtrips, formattign sqls with ids).

I considered also solution with string_agg, which strangely is implemented in MS SQL. But I decided against as primary keys can have different types and this could lead to mess.
