### PR TITLE
Custom attribute to force sql data type in auto schema generation

### DIFF
--- a/src/main/com/fulcrologic/rad/database_adapters/sql/migration.clj
+++ b/src/main/com/fulcrologic/rad/database_adapters/sql/migration.clj
@@ -30,14 +30,10 @@
    :symbol   "VARCHAR(200)"
    :uuid     "UUID"})
 
-;; Add any additional data types you require here
-(def sql-type-map
-  {:text "TEXT"})
-
 (>defn sql-type [{::attr/keys    [type]
                   ::rad.sql/keys [data-type max-length]}]
        [::attr/attribute => string?]
-       (if-let [result (get sql-type-map data-type)]
+       (if-let [result data-type]
          result
          (if (#{:string :password :keyword :symbol} type)
            (if max-length

--- a/src/main/com/fulcrologic/rad/database_adapters/sql/migration.clj
+++ b/src/main/com/fulcrologic/rad/database_adapters/sql/migration.clj
@@ -30,18 +30,24 @@
    :symbol   "VARCHAR(200)"
    :uuid     "UUID"})
 
+;; Add any additional data types you require here
+(def sql-type-map
+  {:text "TEXT"})
+
 (>defn sql-type [{::attr/keys    [type]
-                  ::rad.sql/keys [max-length]}]
-  [::attr/attribute => string?]
-  (if (#{:string :password :keyword :symbol} type)
-    (if max-length
-      (str "VARCHAR(" max-length ")")
-      "VARCHAR(200)")
-    (if-let [result (get type-map type)]
-      result
-      (do
-        (log/error "Unsupported type" type)
-        "TEXT"))))
+                  ::rad.sql/keys [data-type max-length]}]
+       [::attr/attribute => string?]
+       (if-let [result (get sql-type-map data-type)]
+         result
+         (if (#{:string :password :keyword :symbol} type)
+           (if max-length
+             (str "VARCHAR(" max-length ")")
+             "VARCHAR(200)")
+           (if-let [result (get type-map type)]
+             result
+             (do
+               (log/error "Unsupported type" type)
+               "TEXT")))))
 
 (>defn new-table [table]
   [string? => map?]

--- a/src/main/com/fulcrologic/rad/database_adapters/sql_options.cljc
+++ b/src/main/com/fulcrologic/rad/database_adapters/sql_options.cljc
@@ -96,3 +96,7 @@
    has been deleted. The reference on which this option lives is just being changed
    to point to a different thing."
   :com.fulcrologic.rad.database-adapters.sql/delete-referent?)
+
+(def data-type
+  "Attribute option. Force a data type for the desired attribute when auto generating the database."
+  :com.fulcrologic.rad.database-adapters.sql/data-type)

--- a/src/main/com/fulcrologic/rad/database_adapters/sql_options.cljc
+++ b/src/main/com/fulcrologic/rad/database_adapters/sql_options.cljc
@@ -98,5 +98,5 @@
   :com.fulcrologic.rad.database-adapters.sql/delete-referent?)
 
 (def data-type
-  "Attribute option. Force a data type for the desired attribute when auto generating the database."
+  "Attribute option. Force a data type for the desired attribute when auto generating the database, takes a string."
   :com.fulcrologic.rad.database-adapters.sql/data-type)


### PR DESCRIPTION
Added custom data-type attribute to force data type in auto schema generation. Currently I have only added `TEXT` type but others could easily be added into the `sql-type-map`