### PR TITLE
Fix insert of optional enum

### DIFF
--- a/src/main/com/fulcrologic/rad/database_adapters/sql/resolvers.clj
+++ b/src/main/com/fulcrologic/rad/database_adapters/sql/resolvers.clj
@@ -142,7 +142,7 @@
   (cond
     (and (= :ref type) (not= :many cardinality) (eql/ident? form-value)) (second form-value)
     form->sql-value (form->sql-value form-value)
-    (= type :enum) (str form-value)
+    (= type :enum) (when form-value (str form-value))
     :else form-value))
 
 (defn scalar-insert


### PR DESCRIPTION
Fixes issue with insert of enums. If enum was optional and nil, this conversion function caused insert of "" (which failed for me because of foreign constrains).